### PR TITLE
updated source url to use the domain

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ spec:
   source:
     type: Git
     git:
-      uri: http://gogs.$INFRA/$PROJECT/webserver
+      uri: http://gogs.$DOMAIN/$PROJECT/webserver
       ref: master
   output:
     to:


### PR DESCRIPTION
When the build config is being created the domain in the source url was coming out as gogs.infra/

This fixes it to use the DOMAIN from the environment so it should come out as an addressable endpoint for the builder images.
